### PR TITLE
Make the PushChar method virtual to allow inheriting from EmBencode

### DIFF
--- a/EmBencode.h
+++ b/EmBencode.h
@@ -13,14 +13,14 @@ public:
   
   /// Push a string out in Bencode format.
   /// @param str The zero-terminated string to send out (without trailing \0).
-  static void push (const char* str) {
+  void push (const char* str) {
     push(str, strlen(str));
   }
 
   /// Push arbitrary bytes in Bencode format.
   /// @param ptr Pointer to the data to send out.
   /// @param len Number of data bytes to send out.
-  static void push (const void* ptr, uint8_t len) {
+  void push (const void* ptr, uint8_t len) {
     PushCount(len);
     PushChar(':');
     PushData(ptr, len);
@@ -28,7 +28,7 @@ public:
 
   /// Push a signed integer in Bencode format.
   /// @param val The integer to send (this implementation supports 32 bits).
-  static void push (long val) {
+  void push (long val) {
     PushChar('i');
     if (val < 0) {
       PushChar('-');
@@ -40,53 +40,53 @@ public:
 
   /// Start a new new list. Must be matched with a call to endList().
   /// Entries can be nested with more calls to startList(), startDict(), etc.
-  static void startList () {
+  void startList () {
     PushChar('l');
   }
 
   /// Terminate a list, started earlier with a call to startList().
-  static void endList () {
+  void endList () {
     PushEnd();
   }
 
   /// Start a new new dictionary. Must be matched with a call to endDict().
   /// Dictionary entries must consist of a string key plus an arbitrary value.
   /// Entries can be nested with more calls to startList(), startDict(), etc.
-  static void startDict () {
+  void startDict () {
     PushChar('d');
   }
 
   /// Terminate a dictionary, started earlier with a call to startDict().
-  static void endDict () {
+  void endDict () {
     PushEnd();
   }
 
 protected:
   //Works
-  static void PushCount (uint32_t num) {
+  void PushCount (uint32_t num) {
     char buf[11] = {};
     ultoa(num, buf, 10);
     PushData(buf, strlen(buf));
   }
 
   //doesn't work always
-//  static void PushCount (uint32_t num) {
+//  void PushCount (uint32_t num) {
 //    char buf[11];
 //    PushData(ultoa(num, buf, 10), strlen(buf));
 //  }
 
-  static void PushEnd () {
+  void PushEnd () {
     PushChar('e');
   }
 
-  static void PushData (const void* ptr, uint8_t len) {
+  void PushData (const void* ptr, uint8_t len) {
     for (const char* p = (const char*) ptr; len-- > 0; ++p)
       PushChar(*p);
   }
 
-  /// This function is not implemented in the library. It must be supplied by
-  /// the caller to implement the actual writing of caharacters.
-  static void PushChar (char ch);
+  /// This function is not implemented in the library. It must be supplied by the caller
+  /// or inherited from `EmBencode` to implement the actual writing of characters.
+  virtual void PushChar (char ch);
 };
 
 /// Decoder class, needs an external buffer to collect the incoming data.


### PR DESCRIPTION
Dear Jean-Claude,

along the lines of #2 from @einsiedlerkrebs we have another change to *EmBencode* to improve its flexibility. At [Hiveeyes], we are aiming at functionality for automatically fragmenting data payloads.

For doing that, we would like to inherit our custom *[BERadioEncoder]* from the *EmBencode* encoder. To support making the `PushChar` method virtual, we needed to make some other methods non-static.

With kind regards,
Andreas (on behalf of the Hiveeyes team).

P.S.: We are operating one of your JeeLink devices on the gateway side, thanks a bunch for that and also for the opportunity to build our radio link communication upon the EmBencode library, which perfectly fitted our needs. You might also be interested in having a quick look at [BERadio], which is the specification and implementation of a little layer on top of Bencode we follow for encoding our data messages.

[Hiveeyes]: https://hiveeyes.org/docs/system/
[BERadioEncoder]: https://github.com/hiveeyes/arduino/blob/develop/libraries/BERadio/BERadio.cpp#L64
[BERadio]: https://hiveeyes.org/docs/beradio/
